### PR TITLE
Mangle URLs, erase local FS, support new lines

### DIFF
--- a/DoDisplayNotes.js
+++ b/DoDisplayNotes.js
@@ -31,10 +31,11 @@ function DoDisplayNotes(
         var html = "";
         for (var i in this.notes) {
             var n = this.notes[i];
+            var text = replaceNewlinesWithBr(n.text);
             html += FMT_NOTE
                 .replaceAll("%DATE%", formatDate(n.date))
                 .replaceAll("%TERMINAL%", n.terminal)
-                .replaceAll("%TEXT%", n.text);
+                .replaceAll("%TEXT%", text);
         }
         //console.log("ИГР DoDN.displayN-2 html:", html);
         this.elSection.innerHTML = html;

--- a/DoFetchReadOnlyBranches.js
+++ b/DoFetchReadOnlyBranches.js
@@ -49,6 +49,7 @@ function DoFetchReadOnlyBranches() {
             var url = this.readOnlyNoteURLs[branch];
             const params = new NetRequest();
             params.url = url;
+            params.mangleURL = true;
             var res = await loadURL(params);
             //console.log("ИГР DoFROB.loadON-1 url/res:", url, res);
             if (res.status == 200) {

--- a/NetRequest.js
+++ b/NetRequest.js
@@ -1,6 +1,7 @@
 function NetRequest() {
     this._construct = function() {
         this.body = "";
+        this.mangleURL = false;
         this.method = "GET";
         this.url = null;
     };

--- a/index-3.html
+++ b/index-3.html
@@ -24,6 +24,12 @@
         padding: 8px;
         margin-bottom: 8px;
       }
+      .note-date {
+        color: lightgrey;
+      }
+      .note-terminal{
+        color: lightgrey;
+      }
     </style>
   </head>
   <body>
@@ -64,6 +70,8 @@
         <div id="write-div">
           <div>
             <textarea id="write-text" name="write-text" rows="5" cols="35" placeholder="For example: Finally, just NOTES and just GIT, why did it took us SO long?"></textarea>
+          </div>
+          <div>
             <input id="write-post" type="submit" value="Post" />
           </div>
           <div>
@@ -98,10 +106,10 @@
         window.FMT_NOTE = `
 <div class=\"note\">
     <p>
-      <span>%DATE%</span>
-      <span>[%TERMINAL%]</span>
+      <span class=\"note-date\">%DATE%</span>
+      <span class=\"note-terminal\">[%TERMINAL%]</span>
     </p>
-    <h1>%TEXT%</h1>
+    <p class=\"note-text\">%TEXT%</p>
 </div>
 `;
         window.FMT_RAW_GITEA_FILE = "%REPO_URL%/raw/branch/%BRANCH%/%FILE%";

--- a/index-3.html
+++ b/index-3.html
@@ -82,13 +82,22 @@
       </fieldset>
     </form>
 
+    <!-- Erase local FS-->
+    <form id="erase">
+      <fieldset>
+        <legend>Erase local FS</legend>
+        <button onclick="window.indexedDB.deleteDatabase(FS_NAME)">Erase</button>
+      </fieldset>
+    </form>
+
     <!-- Dependencies -->
     <script src="lightning-fs-3.3.6.min.js"></script>
     <script src="isomorphic-git-0.70.7-bundle.umd.min.js"></script>
 
     <!-- Global entities and constants -->
     <script>
-        window.fs = new LightningFS("STORAGE-attempt3");
+        window.FS_NAME = "STORAGE-attempt3";
+        window.fs = new LightningFS(FS_NAME);
         git.plugins.set("fs", window.fs);
         window.pfs = window.fs.promises;
        

--- a/other.js
+++ b/other.js
@@ -47,7 +47,11 @@ async function listBranches() {
 function loadURL(p) {
     return new Promise(function(resolve, reject) {
         var req = new XMLHttpRequest();
-        req.open(p.method, p.url);
+        var url = p.url;
+        if (p.mangleURL) {
+            url += "?" + uuid();
+        }
+        req.open(p.method, url);
         req.onload = function() {
             if (
                 req.readyState == 4 &&

--- a/other.js
+++ b/other.js
@@ -16,6 +16,11 @@ function deId(sid) {
     return document.getElementById(sid);
 }
 
+// Keep newlines in HTML.
+function replaceNewlinesWithBr(text) {
+    return text.replaceAll("\n", "<br>");
+}
+
 // Return date string in YYYY-MM-DD H:m format (or something like that)
 function formatDate(dt) {
     var year = dt.getFullYear();


### PR DESCRIPTION
* Introduce `replaceNewlinesWithBr()` to keep newlines in HTML
* Update `loadURL()` to support URL mangling to work around HTTP caching that prevents `notes.log` to be quickly reloaded from other branches over HTTP
* Add a button to erase local FS and start over